### PR TITLE
feat: allow query cancellation

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 type Author struct {
-	ID            int           `json:"id"`
-	Name          string        `json:"name"`
-	IsPublished   string        `json:"isPublished"`
-	Author        *Author       `json:"author"`
-	Title         string        `json:"title"`
-	Body          string        `json:"body"`
-	keywords      []interface{} `json:"keywords"`
-	RecentArticle *Article      `json:"recentArticle"`
+	ID            int     `json:"id"`
+	Name          string  `json:"name"`
+	IsPublished   string  `json:"isPublished"`
+	Author        *Author `json:"author"`
+	Title         string  `json:"title"`
+	Body          string  `json:"body"`
+	keywords      []interface{}
+	RecentArticle *Article `json:"recentArticle"`
 }
 
 type Image struct {
@@ -3392,9 +3392,9 @@ func TestExecutor(t *testing.T) {
 						"deserializedValue": nil,
 					},
 					"errors": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"locations": []map[string]interface{}{
-								map[string]interface{}{
+								{
 									"line":   3,
 									"column": 13,
 								},
@@ -3501,9 +3501,9 @@ func TestExecutor(t *testing.T) {
 						"deserializedValue": nil,
 					},
 					"errors": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"locations": []map[string]interface{}{
-								map[string]interface{}{
+								{
 									"line":   3,
 									"column": 11,
 								},


### PR DESCRIPTION
Add a second function `ExecuteWithContext` which allows passing a `net.Context` with a query. This context can be canceled, which in turn cancels calling all of the remaining resolver functions. Furthermore, resolver functions can also handle cancellation of the context.

This has the added benefit of guaranteeing all resolvers will be canceled if the main Execute function returns early for any reason.

Signed-off-by: Christian Stewart <christian@paral.in>