### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/utils/cmap.go
+++ b/utils/cmap.go
@@ -29,7 +29,7 @@ func New() ConcurrentMap {
 	return m
 }
 
-// Returns shard under given key
+// GetShard returns shard under given key
 func (m ConcurrentMap) GetShard(key string) *ConcurrentMapShared {
 	hasher := fnv.New32()
 	hasher.Write([]byte(key))
@@ -58,7 +58,7 @@ func (m *ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
 	return !ok
 }
 
-// Retrieves an element from map under given key.
+// Get retrieves an element from map under given key.
 func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	// Get shard
 	shard := m.GetShard(key)
@@ -70,7 +70,7 @@ func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	return val, ok
 }
 
-// Returns the number of elements within the map.
+// Count returns the number of elements within the map.
 func (m ConcurrentMap) Count() int {
 	count := 0
 	for i := 0; i < SHARD_COUNT; i++ {
@@ -94,7 +94,7 @@ func (m *ConcurrentMap) Has(key string) bool {
 	return ok
 }
 
-// Removes an element from the map.
+// Remove removes an element from the map.
 func (m *ConcurrentMap) Remove(key string) {
 	// Try to get shard.
 	shard := m.GetShard(key)
@@ -103,7 +103,7 @@ func (m *ConcurrentMap) Remove(key string) {
 	delete(shard.items, key)
 }
 
-// Checks if map is empty.
+// IsEmpty checks if map is empty.
 func (m *ConcurrentMap) IsEmpty() bool {
 	return m.Count() == 0
 }
@@ -114,7 +114,7 @@ type Tuple struct {
 	Val interface{}
 }
 
-// Returns an iterator which could be used in a for range loop.
+// Iter returns an iterator which could be used in a for range loop.
 func (m ConcurrentMap) Iter() <-chan Tuple {
 	ch := make(chan Tuple)
 	go func() {
@@ -132,7 +132,7 @@ func (m ConcurrentMap) Iter() <-chan Tuple {
 	return ch
 }
 
-// Returns a buffered iterator which could be used in a for range loop.
+// IterBuffered returns a buffered iterator which could be used in a for range loop.
 func (m ConcurrentMap) IterBuffered() <-chan Tuple {
 	ch := make(chan Tuple, m.Count())
 	go func() {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?