### PR TITLE
Implement parsing of multi-line schema item descriptions

### DIFF
--- a/language/lexer.go
+++ b/language/lexer.go
@@ -430,7 +430,10 @@ func LexComment(lexer *Lexer) StateFn {
 	}
 	for {
 		switch rn := lexer.Next(); rn {
-		case -1, '\u000A', '\u000D':
+		case -1:
+			lexer.Backup()
+			return LexText
+		case '\u000A', '\u000D':
 			if rn == '\u000D' && lexer.Peek() == '\u000A' {
 				lexer.Next()
 			}

--- a/language/parser.go
+++ b/language/parser.go
@@ -112,19 +112,29 @@ func (parser *Parser) description() (string, error) {
 	text := ""
 	isBody := false
 	token := parser.lookahead
-	for token.Type == DESCRIPTION {
-		text += strings.Trim(token.Val[2:], " ")
-		if isBody {
-			text += " "
-		} else {
-			isBody = true
+	switch token.Type {
+	case STRING:
+		for token.Type == STRING {
+			text += strings.Trim(token.Val, " ")
+			if isBody {
+				text += " "
+			} else {
+				isBody = true
+			}
+			err := parser.match(STRING)
+			if err != nil {
+				return text, err
+			}
+			token = parser.lookahead
 		}
-		err := parser.match(DESCRIPTION)
+	case MULTILINE_STRING:
+		err := parser.match(MULTILINE_STRING)
 		if err != nil {
 			return text, err
 		}
-		token = parser.lookahead
+		text = strings.Trim(token.Val, "\n")
 	}
+
 	return text, nil
 }
 

--- a/language/parser_test.go
+++ b/language/parser_test.go
@@ -1367,6 +1367,41 @@ input Hello {
 			})
 			So(err, ShouldNotEqual, nil)
 		})
+
+		Convey("multiline descriptions", func() {
+			result, err = parser.Parse(&ParseParams{
+				Source: `
+# Comment
+"""
+Multiline Description on Scalar
+Line 2
+"""
+scalar Scalar
+
+"""
+Multiline Description on Object
+Line 2
+"""
+type Object {
+	"""
+	Multiline Description on Field
+	Line 2
+	"""
+	field: String!
+}
+`,
+			})
+			So(err, ShouldEqual, nil)
+
+			scalar := result.Definitions[0].(*ScalarTypeDefinition)
+			object := result.Definitions[1].(*ObjectTypeDefinition)
+			field := object.Fields[0]
+
+			So(scalar.Description, ShouldEqual, "Multiline Description on Scalar\nLine 2")
+			So(object.Description, ShouldEqual, "Multiline Description on Object\nLine 2")
+			So(field.Description, ShouldEqual, "\tMultiline Description on Field\n\tLine 2\n\t")
+		})
+
 	})
 
 }


### PR DESCRIPTION
This pull allows quoted single-line & multi-line description parsing in graphql schemas.

Fixes https://github.com/playlyfe/go-graphql/issues/45